### PR TITLE
Dynamic linker fixups

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,8 +26,10 @@
            "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
            "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
           },
-          "libraries": [ "-locci", "-lclntsh", "-lnnz12" ],
-          "link_settings": {"libraries": [ "-L<(oci_lib_dir)"] }
+          "link_settings": {
+            "libraries": [ "-L<(oci_lib_dir)", "-lclntsh", "-lnnz12", "-locci" ],
+            "ldflags": [ "-Wl,-rpath,<(oci_lib_dir)" ],
+          },
         }],
         ["OS=='win'", {
           "configurations": {

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,8 +2,8 @@
   "targets": [
     {
       "target_name": "oracle_bindings",
-      "sources": [ "src/connection.cpp", 
-                   "src/oracle_bindings.cpp", 
+      "sources": [ "src/connection.cpp",
+                   "src/oracle_bindings.cpp",
                    "src/executeBaton.cpp",
                    "src/outParam.cpp",
                    "src/reader.cpp",
@@ -15,43 +15,43 @@
             "GCC_ENABLE_CPP_RTTI": "YES"
           },
           "variables": {
-			 "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
-			 "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
+           "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
+           "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
           },
           "libraries": [ "-locci", "-lclntsh", "-lnnz11" ],
-          "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
+          "link_settings": {"libraries": [ "-L<(oci_lib_dir)"] }
         }],
         ["OS=='linux'", {
           "variables": {
-			 "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
-			 "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
+           "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
+           "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
           },
           "libraries": [ "-locci", "-lclntsh", "-lnnz12" ],
-          "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
+          "link_settings": {"libraries": [ "-L<(oci_lib_dir)"] }
         }],
         ["OS=='win'", {
-	  "configurations": {
-          "Release": {
-            "msvs_settings": {
-              "VCCLCompilerTool": {
-                "RuntimeLibrary": "2"
-              }
+          "configurations": {
+            "Release": {
+              "msvs_settings": {
+                "VCCLCompilerTool": {
+                  "RuntimeLibrary": "2"
+                }
+              },
             },
-	  },   
-          "Debug": {
-            "msvs_settings": {
-              "VCCLCompilerTool": {
-              "RuntimeLibrary": "3"
-              }
-            }, 
-	  }
-	  },
+            "Debug": {
+              "msvs_settings": {
+                "VCCLCompilerTool": {
+                "RuntimeLibrary": "3"
+                }
+              },
+            },
+          },
           "variables": {
             "oci_include_dir%": "<!(IF DEFINED OCI_INCLUDE_DIR (echo %OCI_INCLUDE_DIR%) ELSE (echo C:\oracle\instantclient\sdk\include))",
             "oci_lib_dir%": "<!(IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc))",
          },
          # "libraries": [ "-loci" ],
-         "link_settings": {"libraries": [ '<(oci_lib_dir)\oraocci12.lib'] }
+         "link_settings": {"libraries": [ "<(oci_lib_dir)\oraocci12.lib"] }
         }]
       ],
       "include_dirs": [ "<(oci_include_dir)", "<!(node -e \"require('nan')\")" ],
@@ -60,5 +60,3 @@
     }
   ]
 }
-
-

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "~1.18.2"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha -R spec --timeout 10000 test/*.js"
+    "test": "env DYLD_BIND_AT_LAUNCH=1 LD_BIND_NOW=1 ./node_modules/.bin/mocha -R spec --timeout 10000 test/*.js"
   },
   "main": "./index.js",
   "license": {


### PR DESCRIPTION
I've only been able to make this work on Linux so far (see below) and I'm not 100% convinced that linking against a specific .so is a good idea so feedback is welcome.

It only seems to work on OS X when I execute `install_name_tool -id @rpath/libocci.dylib /path/to/libocci.dylib` first, else `-Wl,-rpath,<path>` has no effect...

/cc @raymondfeng
