### PR TITLE
build: make oci version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ If you have VisualStudio 2010 installed,
 
 **Please make sure c:\instantclient_12_1\vc10 comes before c:\instantclient_12_1**
 
+4. Optionally configure the OCI version
+
+`strong-oracle` defaults to OCI v12 (v11 on Mac OS X.)  To make it use an older
+or newer version of the OCI libraries, use the following:
+
+    export GYP_DEFINES="oci_version=11"
+
+On Windows:
+
+    GYP_DEFINES="oci_version=11"
 
 # Examples
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,11 @@
 {
+  "conditions": [
+    ["OS=='mac'", {
+      "variables": { "oci_version%": "11" },
+    }, {
+      "variables": { "oci_version%": "12" },
+    }],
+  ],
   "targets": [
     {
       "target_name": "oracle_bindings",
@@ -18,7 +25,7 @@
             "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
             "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
           },
-          "libraries": [ "-locci", "-lclntsh", "-lnnz11" ],
+          "libraries": [ "-locci", "-lclntsh", "-lnnz<(oci_version)" ],
           "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
         }],
         ["OS=='linux'", {
@@ -26,7 +33,7 @@
             "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
             "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
           },
-          "libraries": [ "-locci", "-lclntsh", "-lnnz12" ],
+          "libraries": [ "-locci", "-lclntsh", "-lnnz<(oci_version)" ],
           "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
         }],
         ["OS=='win'", {
@@ -51,7 +58,7 @@
             "oci_lib_dir%": "<!(IF DEFINED OCI_LIB_DIR (echo %OCI_LIB_DIR%) ELSE (echo C:\oracle\instantclient\sdk\lib\msvc))",
           },
           # "libraries": [ "-loci" ],
-          "link_settings": {"libraries": [ '<(oci_lib_dir)\oraocci12.lib'] }
+          "link_settings": {"libraries": [ '<(oci_lib_dir)\oraocci<(oci_version).lib'] }
         }]
       ],
       "include_dirs": [ "<(oci_include_dir)", "<!(node -e \"require('nan')\")" ],


### PR DESCRIPTION
Make the version of the OCI libraries to link against configurable
through the GYP_DEFINES environment variable.

Fixes #12.

R=@raymondfeng
