### PR TITLE
option getColumnMetaData and result.columnMetaData

### DIFF
--- a/src/connection.h
+++ b/src/connection.h
@@ -105,6 +105,7 @@ public:
       std::vector<row_t*>* rows);
   static Local<Object> CreateV8ObjectFromRow(std::vector<column_t*> columns,
       row_t* currentRow);
+  static Local<Array> CreateV8ArrayFromCols(std::vector<column_t*> columns);
 
   // shared with Statement
   static oracle::occi::Statement* CreateStatement(ExecuteBaton* baton);

--- a/src/executeBaton.cpp
+++ b/src/executeBaton.cpp
@@ -9,6 +9,7 @@ using namespace std;
 ExecuteBaton::ExecuteBaton(Connection* connection,
                            const char* sql,
                            v8::Local<v8::Array> values,
+                           v8::Local<v8::Object> options,
                            v8::Local<v8::Function> callback) {
   this->connection = connection;
   this->connection->Ref();
@@ -17,6 +18,7 @@ ExecuteBaton::ExecuteBaton(Connection* connection,
   this->error = NULL;
   this->callback = callback.IsEmpty() ? NULL : new NanCallback(callback);
   CopyValuesToBaton(this, values);
+  SetOptionsInBaton(this, options);
 }
 
 ExecuteBaton::~ExecuteBaton() {
@@ -141,6 +143,14 @@ void ExecuteBaton::CopyValuesToBaton(ExecuteBaton* baton,
     }
 
   }
+}
+
+void ExecuteBaton::SetOptionsInBaton(ExecuteBaton* baton,
+                                     v8::Local<v8::Object> options) {
+  baton->getColumnMetaData =
+    !options.IsEmpty()
+       ? options->Get(NanNew<String>("getColumnMetaData"))->BooleanValue()
+       : false;
 }
 
 void ExecuteBaton::ResetValues() {

--- a/src/executeBaton.h
+++ b/src/executeBaton.h
@@ -75,6 +75,7 @@ public:
   ExecuteBaton(Connection* connection,
                const char* sql,
                v8::Local<v8::Array> values,
+               v8::Local<v8::Object> options,
                v8::Local<v8::Function> callback = v8::Local<v8::Function>());
 
   ~ExecuteBaton();
@@ -87,6 +88,7 @@ public:
   std::vector<row_t*>* rows; // The list of rows
   std::vector<output_t*>* outputs; // The output values
   std::string* error; // The error message
+  bool getColumnMetaData;
   int updateCount; // The update count
   uv_work_t work_req;
 
@@ -97,6 +99,8 @@ public:
 
   static void CopyValuesToBaton(ExecuteBaton* baton,
                                 v8::Local<v8::Array> values);
+  static void SetOptionsInBaton(ExecuteBaton* baton,
+                                v8::Local<v8::Object> options);
 };
 
 #endif

--- a/src/statementBaton.h
+++ b/src/statementBaton.h
@@ -9,7 +9,7 @@ public:
   StatementBaton(Connection* connection,
                  const char* sql,
                  v8::Local<v8::Array> values = v8::Local<v8::Array>())
-      : ExecuteBaton(connection, sql, values) {
+    : ExecuteBaton(connection, sql, values, Local<Object>()) {
     stmt = NULL;
     done = false;
     busy = false;

--- a/test/integration.js
+++ b/test/integration.js
@@ -240,6 +240,35 @@ describe('oracle driver', function () {
       });
   });
 
+  it("should support select with getColumnMetaData", function(done) {
+    var self = this;
+    self.connection.execute("INSERT INTO person (name) VALUES (:1)", ["Bill O'Neil"], function(err, results) {
+      if(err) { console.error(err); return; }
+      self.connection.execute("SELECT * FROM person", [], {getColumnMetaData:true}, function(err, results) {
+        if(err) { console.error(err); return; }
+        assert.equal(results.length, 1);
+        assert.deepEqual(results.columnMetaData, [ { name: 'ID', type: 4 }, { name: 'NAME', type: 3 } ]);
+        self.connection.execute("SELECT * FROM datatype_test", [], {getColumnMetaData:true}, function(err, results) {
+          if(err) { console.error(err); return; }
+          assert.equal(results.length, 0);
+          assert.deepEqual(results.columnMetaData,
+                           [ { name: 'ID', type: 4 },
+                             { name: 'TVARCHAR2', type: 3 },
+                             { name: 'TNVARCHAR2', type: 3 },
+                             { name: 'TCHAR', type: 3 },
+                             { name: 'TNCHAR', type: 3 },
+                             { name: 'TNUMBER', type: 4 },
+                             { name: 'TDATE', type: 5 },
+                             { name: 'TTIMESTAMP', type: 6 },
+                             { name: 'TCLOB', type: 7 },
+                             { name: 'TNCLOB', type: 7 },
+                             { name: 'TBLOB', type: 8 } ]);
+          done();
+        });
+      });
+    });
+  });
+
   // FIXME: [rfeng] Investigate why the following test is failing
   /*
   it("should support utf8_chars_in_query", function (done) {

--- a/test/outparams.js
+++ b/test/outparams.js
@@ -214,15 +214,23 @@ describe('stored procedures with out params', function () {
 
   it("should support cursor out param", function (done) {
     var self = this;
-    self.connection.execute("call procCursorOutParam(:1)",
-      [new oracle.OutParam(oracle.OCCICURSOR)], function (err, results) {
-        if (err) {
-          done(err);
-          return;
-        }
-        assert.equal(results.returnParam.length, 0);
-        done();
-      });
+
+    self.connection.execute("DELETE FROM person", [], function (err, results) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      self.connection.execute("call procCursorOutParam(:1)",
+        [new oracle.OutParam(oracle.OCCICURSOR)], function (err, results) {
+          if (err) {
+            done(err);
+            return;
+          }
+          assert.equal(results.returnParam.length, 0);
+          done();
+        });
+     });
   });
 
   it("should support clob out param", function (done) {


### PR DESCRIPTION
This pull request adds an options argument to connection.execute as an optional 3rd argument. This allows specification of {getColumnMetaData:true} as the options argument. 

Regression tests added. Existing tests pass. I will modify the documentation here if/when API is nailed down.
(And then there's the test suite issue I mentioned here: https://github.com/strongloop/strong-oracle/issues/19#issuecomment-71057152)

Current API example:
~~~
    connection.execute(
        "SELECT * FROM person", [], {getColumnMetaData:true},
        function(err, results) {
            if ( err ) { ... } 
            // results.columnMetaData = [ { name: 'ID', type: 4 }, { name: 'NAME', type: 3 } ]
            connection.close();
        }
    );
~~~
Thank you