### PR TITLE
Fix readme OCI_LIB_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ On MacOS or Linux:
 MacOS/Linux:
 
     export OCI_HOME=<directory of Oracle instant client>
-    export OCI_LIB_DIR=$OCI_HOME
+    export OCI_LIB_DIR=$OCI_HOME/lib/
     export OCI_INCLUDE_DIR=$OCI_HOME/sdk/include
 
 2. Create the following symbolic links


### PR DESCRIPTION
On my env:
```
(readmefix ✓)❯ echo $OCI_HOME
/usr/lib/oracle/11.2/client64
(readmefix ✓)❯ echo $OCI_LIB_DIR
/usr/lib/oracle/11.2/client64/lib
(readmefix ✓)❯ echo $OCI_INCLUDE_DIR
/usr/include/oracle/11.2/client64
```

