### PR TITLE
Fixed invalid data when using blob data type

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -875,9 +875,9 @@ Local<Object> Connection::CreateV8ObjectFromRow(vector<column_t*> columns,
       case VALUE_TYPE_BLOB: {
         buffer_t *v = (buffer_t *) val;
         // convert to V8 buffer
-        v8::Local<v8::Object> v8Buffer = NanBufferUse((char *)v->data, v->length);
+        v8::Local<v8::Object> v8Buffer = NanBufferUse((char *)v->data, (uint32_t)v->length);
         obj->Set(NanNew<String>(col->name.c_str()), v8Buffer);
-        delete[] v->data;
+        // Nan will free the memory of the buffer
         delete v;
         break;
       }


### PR DESCRIPTION
The previous implementation was freeing the memory before it was used which leaded to corrupted data when using blobs.

NanBufferUse automatically frees the memory see https://github.com/rvagg/nan#api_nan_buffer_use

I also added casting to the correct length type (uint32_t) (4 Bytes) from size_t (8 Bytes). 