### PR TITLE
Reader Memory Leak

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -90,7 +90,7 @@ Reader.prototype.nextRow = function (cb) {
   var self = this;
   if (!self._handle || self._error || (self._rows && self._rows.length > 0)) {
     process.nextTick(function () {
-      cb(self._error, self._rows && self._rows.shift());
+      return cb(self._error, self._rows && self._rows.shift());
     });
   } else {
     // nextRows willl use the prefetch row count as window size
@@ -100,7 +100,7 @@ Reader.prototype.nextRow = function (cb) {
       if (err || result.length === 0) {
         self._handle = null;
       }
-      cb(self._error, self._rows && self._rows.shift());
+      return cb(self._error, self._rows && self._rows.shift());
     });
   }
 };


### PR DESCRIPTION
Adding returns to the callbacks in `nextRow` resolves a memory leak and also a strong performance improvment.