### PR TITLE
Ppc64fix

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,9 @@
     }, {
       "variables": { "oci_version%": "12" },
     }],
+    ["OS=='linux' and target_arch=='ppc64'", {
+      "variables": { "oci_version%": "11" },
+    }],
   ],
   "targets": [
     {


### PR DESCRIPTION
Fixed the binding.gyp file by adding a condition that checks if it is ppc64. There is no oracle instantclient version 12 for power so we have to make sure binding.gyp knows that it is version 11 when the machine is Linux on power.