### PR TITLE
instant client v12 is now out on ppc64

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,9 +5,6 @@
     }, {
       "variables": { "oci_version%": "12" },
     }],
-    ["OS=='linux' and target_arch=='ppc64'", {
-      "variables": { "oci_version%": "11" },
-    }],
   ],
   "targets": [
     {


### PR DESCRIPTION
remove check for ppc64 which sets instant client version to 11