### PR TITLE
Fix issue with gcc5 and occi based on gcc4

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -33,6 +33,7 @@
             "oci_include_dir%": "<!(if [ -z $OCI_INCLUDE_DIR ]; then echo \"/opt/instantclient/sdk/include/\"; else echo $OCI_INCLUDE_DIR; fi)",
             "oci_lib_dir%": "<!(if [ -z $OCI_LIB_DIR ]; then echo \"/opt/instantclient/\"; else echo $OCI_LIB_DIR; fi)",
           },
+          "defines": ["_GLIBCXX_USE_CXX11_ABI=0"],
           "libraries": [ "-locci", "-lclntsh", "-lnnz<(oci_version)" ],
           "link_settings": {"libraries": [ '-L<(oci_lib_dir)'] }
         }],


### PR DESCRIPTION
After updating to a newer my Linux distro I got strange errors with strong-oracle e.g.:

[Error: ORA-24960: the attribute  OCI_ATTR_USERNAME is greater than the maximum allowable length of 255]

and a crash after that.

After some research I found out that gcc 5 uses a new ABI and is incompatible with the occi that used gcc4. (See http://stackoverflow.com/questions/32309029/occi-linkage-error-with-gcc-5)

This fix adds the required definition so that the new ABI is disabled, older gcc ignore the definition.