### PR TITLE
Remove segfault-handler

### DIFF
--- a/lib/oracle.js
+++ b/lib/oracle.js
@@ -1,10 +1,3 @@
-try {
-  var SegfaultHandler = require('segfault-handler');
-  SegfaultHandler.registerHandler();
-} catch(err) {
-// Ignore error
-}
-
 var bindings = null;
 try {
   // Try the release version

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "async": "^1.4.0",
     "mocha": "~2.2.5"
   },
-  "optionalDependencies": {
-    "segfault-handler": "^0.2.4"
-  },
   "scripts": {
     "pretest": "node pretest.js",
     "test": "./node_modules/.bin/mocha -R spec --timeout 10000 test/*.js"


### PR DESCRIPTION
It sets up process wide handling of SIGSEGV, a policy decision that
should be left to the app developer, not made by low-level packages.